### PR TITLE
docs: SkeletonBlock width and height should be type  of string

### DIFF
--- a/src/react/index.md
+++ b/src/react/index.md
@@ -93,8 +93,8 @@ Skeleton block is just a usual block element with gray background color, that ca
 | Name     | Type     | Default | Description                                         |
 | -------- | -------- | ------- | --------------------------------------------------- |
 | `tag`    | `string` | `'div'` | HTML element tag                                    |
-| `width`  | `number` |         | Block CSS width                                     |
-| `height` | `number` |         | Block CSS height                                    |
+| `width`  | `string` |         | Block CSS width                                     |
+| `height` | `string` |         | Block CSS height                                    |
 | `effect` | `string` |         | Loading effect, can be `fade` or `pulse` or `blink` |
 
 ### SkeletonText

--- a/src/svelte/index.md
+++ b/src/svelte/index.md
@@ -93,8 +93,8 @@ Skeleton block is just a usual block element with gray background color, that ca
 | Name     | Type     | Default | Description                                                           |
 | -------- | -------- | ------- | --------------------------------------------------------------------- |
 | `tag`    | `string` | `'div'` | HTML element tag, can be `div`, `p`, `h1`, `h2`, `h3`, `h4` or `span` |
-| `width`  | `number` |         | Block CSS width                                                       |
-| `height` | `number` |         | Block CSS height                                                      |
+| `width`  | `string` |         | Block CSS width                                                       |
+| `height` | `string` |         | Block CSS height                                                      |
 | `effect` | `string` |         | Loading effect, can be `fade` or `pulse` or `blink`                   |
 
 ### SkeletonText

--- a/src/vue/index.md
+++ b/src/vue/index.md
@@ -95,8 +95,8 @@ Skeleton block is just a usual block element with gray background color, that ca
 | Name     | Type     | Default | Description                                         |
 | -------- | -------- | ------- | --------------------------------------------------- |
 | `tag`    | `string` | `'div'` | HTML element tag                                    |
-| `width`  | `number` |         | Block CSS width                                     |
-| `height` | `number` |         | Block CSS height                                    |
+| `width`  | `string` |         | Block CSS width                                     |
+| `height` | `string` |         | Block CSS height                                    |
 | `effect` | `string` |         | Loading effect, can be `fade` or `pulse` or `blink` |
 
 ### SkeletonText


### PR DESCRIPTION
`SkeletonBlock` properties `width` and `height` should be `string` instead of `number`.

Usage in demos:
```html
<SkeletonBlock width="30%" height="0.75em" />
```

assignment: 
```js
if (width) skeletonStyle.width = width;
```

in `SkeletonBlock.d.ts` its `string` too.